### PR TITLE
Remove redundant info

### DIFF
--- a/gov.qmd
+++ b/gov.qmd
@@ -5,32 +5,32 @@ toc: true
 
 Our Data Governance team works collaboratively across Fred Hutch to build a network for ethical data use and stewardship supports. By partnering with departments such as Legal, Compliance, Business Development and Information Security, we support communication and documentation to increase staff awareness of data governance policies and procedures. The Data Governance team helps investigators navigate data policy and governance resources, such as data use agreements, software licensing, and IRB guidance. We also contribute to and facilitate organization-wide initiatives related to data governance such as Cancer Consortium data sharing, connecting patients’ data to research and staff data stewardship literacy. 
 
-
+::: {.callout-note appearance="minimal"}
 ## Data Governance Efforts
 Data governance and stewardship can be defined as the collection of institutional policies, processes, and procedures that support ethical, compliant data use using our particular technology, tools and data assets. Our Data Governance team works to support the coordinated effort done by a variety of subject matter experts and departments at Fred Hutch to enable staff to leverage data best practices to ensure clinical and research staff have the ability to use high quality, timely data in their everyday work.  Through training and awareness, we aim to support responsible, ethical data use in clinical care and research.   
+:::
 
-
-### [Cancer Consortium](https://www.cancerconsortium.org/) Data Governance & Sharing
+## [Cancer Consortium](https://www.cancerconsortium.org/) Data Governance & Sharing
 
 Since its designation as a National Cancer Institute (NCI) Comprehensive Cancer Center in 1973, the Fred Hutch/University of Washington/Seattle Children’s Cancer Consortium has demonstrated a commitment to excellence in cancer research and treatment. An important part of our success as a Consortium are the data sharing relationships we maintain to facilitate cross-institutional clinical care and research. 
 
-#### UW Medicine - Fred Hutch Joint Clinical Data Governance 
+### UW Medicine - Fred Hutch Joint Clinical Data Governance 
 The Clinical Data Exchange Memorandum of Understanding (MOU) between Fred Hutch and UW went into effect on April 18, 2023, and called for an ongoing joint governance structure that will oversee the Parties’ collaboration relating to all Exchanged Clinical Data for Cancer-Related Care, Healthcare Operations, and Research. This joint governance structure between Fred Hutch and the University of Washington related to clinical data exchange includes an Oversight committee as well as a sub-committee which serves to address joint decision making in an ongoing way.  
 
 
 
-#### Seattle Children's Hosptial - Fred Hutch Governance
+### Seattle Children's Hosptial - Fred Hutch Governance
 Fred Hutch has a data sharing partnership with Seattle Children's Hospital.  Our [Centernet page](https://centernet.fredhutch.org/u/data-science-lab/sch-research.html) outlines some key resources prepared by the Research Data Governance Subcommittee (RDGS) related to the exchange of data for research purposes. 
 
 
-### Patient and Research Data Governance & Stewardship
+## Patient and Research Data Governance & Stewardship
 
-#### Patient Data for Research
+### Patient Data for Research
 
 OCDO serves as a gatekeeper/honest broker to help ensure that patient data for research is provided in alignment with applicable regulations, policies, standards, IRB approvals, and/or other contractual obligations. See our [Clinical Data Access Data House Call](https://calendly.com/data-house-calls/clinical-data) for more information. 
 
 
-#### Research Data Stewardship
+### Research Data Stewardship
 
 We provide support for leveraging restricted use research data and facilitating compliant data sharing. 
 
@@ -41,7 +41,7 @@ We provide support for leveraging restricted use research data and facilitating 
 - NIH Data Management and Sharing Plans and guidance (see [dmptool.org](https://dmptool.org/) and our [Biomedical Data Science Wiki supports for developing and implementing your plans](https://sciwiki.fredhutch.org/datascience/nih_data_sharing/))
 
 
-### AI Governance
+## AI Governance
 We strive to enable the Fred Hutch community to make use of the benefits of AI systems for work-related activities, while mitigating risk and upholding Fred Hutch’s values in the rapidly evolving AI landscape. There are some important issues to think about when contemplating the use of an AI based tool as part of your work.  Considerations include: 
 
 - what type of AI system you’re working with, 
@@ -55,12 +55,11 @@ Fred Hutch focused AI resources and governance processes are currently in develo
 
 ## Connect with Us
 
-Email questions about data governance generally to [datagovernance@fredhutch.org](mailto:datagovernance@fredhutch.org) or connect with us through our Data House Calls program. 
+Email questions about data governance generally to [datagovernance@fredhutch.org](mailto:datagovernance@fredhutch.org) or connect with us through our [Data House Calls](programs/dhc) program. 
 
 - [Data Policy and AI](https://calendly.com/data-house-calls/data-policy) House Call: questions about data policy, data protection and AI use cases.
-
-  > Note, many of these topics can be supported by various other subject matter expert groups at the Fred     Hutch. This DHC serves primarily as advice where DaSL is responsible for aspects of these issues and     navigation support for finding an expert to help you for those aspects that we are not.
-
 - [Clinical Patient Data Access](https://calendly.com/data-house-calls/clinical-data) House Call: questions about Fred Hutch adult oncology clinical patient data access for research and it's oversight.  
 - [Data Sharing, Study Planning and Grants](https://calendly.com/data-house-calls/sharing): questions about data sharing and planning.
+
+For a full description of data house calls, see the [Data House Calls](programs/dhc) program page.
 


### PR DESCRIPTION
An opinionated edit. Remove text that is already on the DHC page. Otherwise we're updating in two places and have forking paths of future edits.