### PR TITLE
updates to community page and fixing openscapes typos

### DIFF
--- a/programs/communities.qmd
+++ b/programs/communities.qmd
@@ -3,39 +3,14 @@ title: "DaSL Learning Communities"
 toc: true
 ---
 
-
 DaSL Learning Communities are events designed to catalyze community and conversations around shared workflows and interests in biomedical data science topics. They are spaces where folks from across Fred Hutch and the Cancer Consortium can meet to see new methods and ways of working, to share their own insights into their work, and to get constructive feedback about how they could improve their computing work.
 
 In Learning Communities we hold closely the belief that we are all on the same team. Even though you may be the only computing or data science practitioner in your working group, we are committed to creating an environment where all feel welcome to share their experiences. This way, despite the challenges we face in our work, we can all learn from each other and improve our skills.
 
 DaSL employees will moderate, attend, and occasionally present on topics in the Learning Communities. 
 
-::: {.callout-note title="Learning Communities Mission Statement"}
+For more information, please see <https://hutchdatascience.org/community/>. 
 
-DaSL Learning Communities aim to provide a psychologically safe, professional environment to co-learn topics in biomedical data science and to share and apply this knowledge together across groups at Fred Hutch.
+::: {.callout-important}
+Please note that you may have to disable your VPN if you are on the clinical network to see the community page.
 :::
-
-## Learning Community Events
-
-All communities are open and available to everyone in the Fred Hutch Consortium community. Some events are remote, and some are hybrid / in-person. Stay tuned for more information.
-
-The following is a list of events for the current quarter. You can RSVP for any event by clicking on it.
-
-<div style="width:100%;height:500px;" class="ae-emd-cal-events" data-calendar="ou823213" data-lbl-upcoming="Upcoming events" data-lbl-subscribe="Subscribe" data-no-events="No events found.." data-lbl-readmore="Read more" data-lbl-in="In" data-lbl-days="days" data-lbl-day="day" data-lbl-hours="hours" data-lbl-hour="hour" data-lbl-minutes="minutes" data-lbl-minute="minute" data-lbl-seconds="seconds" data-lbl-second="second" data-lbl-live="LIVE" data-include-atc="true" data-include-stc="true" data-include-moupcpicker="true" data-include-location="false" data-include-timezone="false" data-include-organizer="false" data-include-countdown="false" data-include-description="false" data-include-timezone-select="true" data-default-view="upcoming" data-stayonpage="false" data-datetime-format="1" data-datetime-language="en_US" data-events-max="20" data-description-length="brief" ></div><script type="text/javascript" src="https://cdn.addevent.com/libs/cal/js/cal.events.embed.t4.init.js"></script>
-
-### Learning Community Values:
-
-- Research doesn’t need to be lonely. We learn and work best with our peers.
-- The ways that data impacts our work at Fred Hutch are wide and varied. There is no one right way, but there are best practices we can aspire to.
-- Sharing knowledge in public is important. Together, our collective knowledge can help us all improve how we work. Everyone knows something that could help someone else in our community.
-- Asking questions is a way of taking care of our peers. They often may have the same questions, but might be reluctant to ask them.
-
-### Participation Guidelines
-
-Please be aware that all Learning Community events adhere to the [Learning Community Participation Guidelines](../pages/participation.qmd). This is to make a safe space for all.
-
-## Interested? Join us!
-
-[Join the FH Data Slack](https://join.slack.com/t/fhdata/signup) to find community support and join our training mailing list by emailing [data@fredhutch.org](emailto:data@fredhutch.org).
-
-

--- a/programs/openscapes.qmd
+++ b/programs/openscapes.qmd
@@ -16,7 +16,7 @@ Do you or your team...
 - Need to use new data science tools but don’t know where to start?
 - Work in isolation, but want to collaborate more often?
 - Want to make your science more reproducible?
-- Want to work alongside other teams to implement new practices for data analysis & stewardship.
+- Want to work alongside other teams to implement new practices for data analysis & stewardship?
 
 If yes, the Openscapes Champions may be a good fit!
 
@@ -57,13 +57,13 @@ The cohort meeting time is: 10am to 11:30am PT
 
 In addition to the cohort meetings times, there will be 4 optional co-working times scheduled between the cohort meeting times.
 
-To apply, please fill out the form here to nominate yourself or you group: [Openscapes 2025 Application](https://forms.gle/2SVfjvfCrAP87Hrt8)
+To apply, please fill out the form here to nominate yourself or your group: [Openscapes 2025 Application](https://forms.gle/2SVfjvfCrAP87Hrt8)
 
 For more information email us at `data@fredhutch.org`.
 
 ### Testimony from the 2023 Champions Cohort
 
-The [fall 2023 Champions Cohort](https://openscapes.github.io/2023-fred-hutch/) included the the Berger Lab, Setty Lab, and Ha Lab. A recap of some of the work thse teams accomplished is on the [Openscapes blog](https://openscapes.org/blog/2023-12-04-fred-hutch/).
+The [fall 2023 Champions Cohort](https://openscapes.github.io/2023-fred-hutch/) included the the Berger Lab, Setty Lab, and Ha Lab. A recap of some of the work these teams accomplished is on the [Openscapes blog](https://openscapes.org/blog/2023-12-04-fred-hutch/).
 
 ::: columns
 ::: {.column width="30%"}


### PR DESCRIPTION
Fixed typos in openscapes and pared down community page to point to hutchdatascience.org