### PR TITLE
Fixing FH cBioPortal documentation links

### DIFF
--- a/dss.qmd
+++ b/dss.qmd
@@ -33,7 +33,7 @@ We're developing resources in collaboration with the Fred Hutch IT Scientific Co
 
 **Research Data Applications**
 
-We support the private [Fred Hutch instance of cBioPortal](https://sciwiki.fredhutch.org/datascience/cbioportal/) in collaboration with Fred Hutch IT's [Scientific Computing group](https://centernet.fredhutch.org/u/it/scicomp.html). cBioPortal allows users to easily explore multidimensional cancer genomics data with an intuitive point-and-click interface. For more information, read the [SciWiki documentation](https://sciwiki.fredhutch.org/datademos/fh-cbio-intro/) and visit [cbioportal.fredhutch.org](https://cbioportal.fredhutch.org) to try it out.
+We support the private [Fred Hutch instance of cBioPortal](https://sciwiki.fredhutch.org/datascience/cbioportal/) in collaboration with Fred Hutch IT's [Scientific Computing group](https://centernet.fredhutch.org/u/it/scicomp.html). cBioPortal allows users to easily explore multidimensional cancer genomics data with an intuitive point-and-click interface. For more information, read the [SciWiki documentation](https://sciwiki.fredhutch.org/datascience/cbioportal/) and visit [cbioportal.fredhutch.org](https://cbioportal.fredhutch.org) to try it out.
 
 ### Connect with us
 

--- a/tools.qmd
+++ b/tools.qmd
@@ -40,7 +40,7 @@ The [Fred Hutch deployment of cBioPortal](https://cbioportal.fredhutch.org/) pro
 - Additionally, this instance and our administration plans have been reviewed and approved by InfoSec to allow users to include individually identifiable research data in their data uploads when investigators have clear IRB approvals in place. 
 
 ::: {.callout-note appearance="minimal"}
-For more details on what the Fred Hutch instance of cBioPortal can do for you, read our Fred Hutch cBioPortal [product page](https://sciwiki.fredhutch.org/datascience/cbioportal/) and [documentation](https://sciwiki.fredhutch.org/dasldemos/fh-cbio-intro/) on the Fred Hutch SciWiki and visit [cbioportal.fredhutch.org](https://cbioportal.fredhutch.org) to give it a spin.
+For more details on what the Fred Hutch instance of cBioPortal can do for you, read our Fred Hutch cBioPortal [product page](https://sciwiki.fredhutch.org/datascience/cbioportal/) on the Fred Hutch SciWiki and visit [cbioportal.fredhutch.org](https://cbioportal.fredhutch.org) to give it a spin.
 :::
 
 ## Translational Applications and Tools


### PR DESCRIPTION
## Description
- With recent cBioPortal documentation updates in SciWiki, we need to update corresponding links on the OCDO website.

## Testing
- See rendered link below.