### PR TITLE
Replace Outlook links with Calendly for scheduling

### DIFF
--- a/programs/dhc.qmd
+++ b/programs/dhc.qmd
@@ -113,7 +113,7 @@ Schedule this [Data House Call](https://calendly.com/data-house-calls/computing)
 
 We are here to field questions about writing code, working with software, managing computing environments, and research software development. Use this [Data House Call](https://calendly.com/data-house-calls/code) if you are working with or learning:
 
-- R/ Python/Bash
+- R/Python/Bash
 - Conda/Docker
 - Git/GitHub
 - Jupyter/RStudio


### PR DESCRIPTION
Updated scheduling links from Outlook to Calendly for various Data House Calls. Adjusted descriptions to reflect the new scheduling process and clarified notes for Fred Hutch staff regarding network access.