### PR TITLE
forcer docker image removal

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -30,7 +30,7 @@ test:
       alias: ocdo
   script:
     - sleep 15 && curl -sI  http://ocdo:80  |head -1|grep -q "200 OK"
-    - if [[ -n "$CI_COMMIT_BRANCH" ]] && [[ "$CI_COMMIT_BRANCH" != "main" ]]; then docker rmi sc-registry.fredhutch.org/ocdo:$CI_COMMIT_SHORT_SHA ; fi
+    - if [[ -n "$CI_COMMIT_BRANCH" ]] && [[ "$CI_COMMIT_BRANCH" != "main" ]]; then docker rmi --force sc-registry.fredhutch.org/ocdo:$CI_COMMIT_SHORT_SHA ; fi
 deploy:
   stage: deploy
   only:


### PR DESCRIPTION
We ran a build after merging @dtenenba PR  #112 but  it failed in the test step with 

```bash
Error response from daemon: conflict: unable to remove repository reference "sc-registry.fredhutch.org/ocdo:a3ef4689" (must force) - container 0c405f422006 is using its referenced image d2f1322f6ec1
```

https://build-logs.fredhutch.org/job/51243

Or is there a better solution?